### PR TITLE
101: Enable automatic restart from parameter scan history files

### DIFF
--- a/docs/job_dictionary.rst
+++ b/docs/job_dictionary.rst
@@ -1,0 +1,91 @@
+Job Dictionary
+==============
+
+A Job dictionary is maintained by each worker during execution of the codes list
+(defined in the the configuration file. The purpose of the Job dictionary is to provide a mutable
+object that user's can read from and write to if they are using preprocessing or postprocessing
+functions to make modifications between simulations in the code list. The Job dictionary is also passed
+to the objective function to provide information about the final state of the job.
+
+The Job dictionary will always contain several pre-populated fields containing information about
+the state of the job. These can be read from or even overwritten by the pre/postprocess functions.
+However, in the latter case caution is advised as this can certainly break the rsopt run if not done properly.
+Pre-populated fields are:
+
+- `inputs`: This is a dictionary of parameters and settings for the job being run. This is populated
+  for each job before preprocess is called. Because any inputs files are written after preprocess is called
+  this allows users to make modifications or additions to the `inputs` dictionary. This is useful setting
+  covariables in particular. An example of covariable setting is shown below:
+
+  .. code-block:: python
+   :linenos:
+      # Before preprocess is called let the state of J, set by rsopt be:
+      J = {'inputs':
+              # Our simulation function has one variable 'x' that has been assigned a value already
+              {'x': 5.0}
+          }
+
+  .. code-block:: python
+   :linenos:
+
+      def my_preprocess(J):
+         # Let's say we want a linear relationship between the variable 'x' which is being set by
+         #  rsopt directly and another input variable in the simulation 'y'. This can't be written
+         #  into the rsopt configuration file but we can enforce it here. If we write a value for 'y'
+         #  into J['inputs'] it will be passed to the simulation function.
+
+         # Current value of x
+         x = J['inputs']['x']
+         # Set y based on a linear relationship with x
+         y = 3 * x
+         # Create an entry for y in the Job dictionary inputs field
+         J['inputs']['y'] = y
+
+         # No return value needs to be set for pre/postprocess functions
+
+- `sim_status`: This is an integer code that is set after a simulation has finished that details whether the simulation
+  finished successfully or not; or if something else happened. It is only available for use with postprocess functions
+  and objective functions.
+  This status is actually being set and used by the libEnsemble library that rsopt uses. For a list of statuses and
+  their descriptions see calc_status_. This can be useful for instance to check if a Job failed to complete fully.
+  The state can be checked in the objective function and used to invoke alternate calculation routines if a penalty
+  function needs to be evaluated.
+
+  .. code-block:: python
+   :linenos:
+   from libensemble import message_numbers
+   import h5py
+   import numpy as np
+
+   """
+   Suppose a simulation runs and produces an output file 'my_result.h5'. For the sake of this example we will
+   assume that if the simulation finishes successfully this file will always contain fifty, positively valued entries
+   and we want to minimize the total of these numbers.
+   If the simulation does not complete then some of these will be missing and we will need to account for this when
+   writing the objective function.
+   """
+
+
+   def my_objective(J):
+       MAX_ENTRIES = 50
+       ENTRY_PENALTY_VALUE = 100.0
+       if J['sim_status'] == message_numbers.WORKER_DONE:
+           # Job finished successfully - assume all entries are present - normal evaluation
+           result_file = h5py.File('my_result.h5', 'r')
+           result = np.sum(result_file['x'][()])
+
+           return result
+       elif J['sim_status'] == message_numbers.TASK_FAILED:
+           # Some number of entries will be missing
+           # Find out how many and replace their value with ENTRY_PENALTY_VALUE
+           result_file = h5py.File('my_result.h5', 'r')
+           missing_count = MAX_ENTRIES - result_file['x'].size
+           result = np.sum(result_file['x'][()]) + missing_count * ENTRY_PENALTY_VALUE
+
+           return result
+       else:
+           # Maybe some unknown failure state can occur. Perhaps you would just want to return
+           # the max penalty in this case
+           return MAX_ENTRIES * ENTRY_PENALTY_VALUE
+
+.. _calc_status: https://libensemble.readthedocs.io/en/main/data_structures/calc_status.html

--- a/examples/sampler_restart/README
+++ b/examples/sampler_restart/README
@@ -1,0 +1,22 @@
+In this example we show how to restart a partially completed scan. This can be useful if you were running a job
+at a cluster with timed allocation and reached the time limit or if an error caused rsopt to previously crash.
+
+To start we will run the configuration file config_scan.yml which is performing a uniform gridded scan over
+the 2D Rosenbrock function. A known point in the scan is set to trigger an error which will cause rsopt to abort
+(see rosenbrock_raise in func.py).
+
+To start run in a terminal:
+    rsopt sample configuration config_scan.yml
+
+An error will occur around evaluation 500: 'AssertionError: An expected error occurred!'
+and the history up to the error will automatically be written out. All planned evaluations are already in the history
+they just don't have results yet so we can pass that history to rsopt and tell it to restart and run any unevaluated points.
+
+First we need to make sure the run won't fail again. Make 2 changes in config_scan.yml:
+    - On line 18 change 'rosenbrock_raise' to 'rosenbrock'
+    - On line 24 change 'scan_rosenbrock' to 'restart_scan'
+
+To restart the scan in a terminal run (fill in the appropriate history name, it may differ a little each time):
+    rsopt sample restart config_scan.yml libE_history_at_abort...
+
+Now the remaining ~2000 points show be evaluated and saved in a new history file!

--- a/examples/sampler_restart/config_scan.yml
+++ b/examples/sampler_restart/config_scan.yml
@@ -1,0 +1,23 @@
+codes:
+    - python:
+        settings:
+            a: 1.0
+        parameters:
+            x: 
+                min: -2            
+                max:  2            
+                start: 1.2  
+                samples: 50
+            y:             
+                min: -1            
+                max:  3           
+                start: 1.9 
+                samples: 50
+        setup:           
+            input_file: func.py   
+            function: rosenbrock_raise
+            execution_type: serial
+options:
+    software: mesh_scan
+    nworkers: 4
+    run_dir: scan_rosenbrock

--- a/examples/sampler_restart/func.py
+++ b/examples/sampler_restart/func.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+
+def rosenbrock(x, y, a=0, b=100):
+    f = (a - x)**2 + b*(y - x**2)**2
+    return f
+
+
+def rosenbrock_raise(x, y, a=0, b=100):
+    assert not np.all(np.isclose([-1.75510204, -0.18367347], [x, y])), "An expected error occurred!"
+    f = (a - x)**2 + b*(y - x**2)**2
+    return f

--- a/rsopt/configuration/options/__init__.py
+++ b/rsopt/configuration/options/__init__.py
@@ -64,11 +64,13 @@ class Options:
 
     @classmethod
     def _check_options(cls, options):
+        # Ensure all required keys/values for an options class are in the parsed input
         name = cls.NAME
         for key in cls.REQUIRED_OPTIONS:
             assert options.get(key), f"{key} must be defined in options for {name}"
 
     def _validate_input(self, name, value):
+        # Ensure each option key is recognized. Check typing for each option value.
         co = self._REGISTERED_OPTIONS[self.NAME]
         if name not in co.keys() and name not in self.REQUIRED_OPTIONS:
             raise KeyError(f'options {name} was not recognized')
@@ -88,6 +90,7 @@ class Options:
             self.__setattr__(name, value)
 
     def get_objective_function(self):
+        # import the objective function if given
         if len(self.objective_function) == 2:
             module_path, function = self.objective_function
             sys.path.append(os.getcwd())
@@ -99,6 +102,10 @@ class Options:
         return function
 
     def get_sim_specs(self):
+        # This is the most common sim_spec setting. It is updated by libEnsembleOptimizer if a different value needed.
+        # TODO: It's not clear why this is defined here.
+        #  It is something that will vary by Option class but is otherwise static.
+        #  Maybe it should be put into the options schema?
         sim_specs = {
             'in': ['x'],
             'out': [('f', float), ]

--- a/rsopt/libe_tools/optimizer.py
+++ b/rsopt/libe_tools/optimizer.py
@@ -3,7 +3,8 @@ from rsopt.libe_tools.generator_functions.local_opt_generator import persistent_
 from libensemble.alloc_funcs.persistent_aposmm_alloc import persistent_aposmm_alloc
 from libensemble.tools import check_inputs
 from libensemble.tools import add_unique_random_streams
-from rsopt.optimizer import Optimizer, OPTIONS_ALLOWED
+from rsopt.libe_tools import tools
+from rsopt.optimizer import Optimizer
 from rsopt.libe_tools.interface import get_local_optimizer_method
 from rsopt.simulation import SimulationFunction
 from pykern import pkyaml
@@ -76,7 +77,7 @@ class libEnsembleOptimizer(Optimizer):
 
     def _configure_optimizer(self):
         local_opt_method = get_local_optimizer_method(self._config.method, self._config.software)
-        gen_out = [set_dtype_dimension(dtype, self.dimension) for dtype in persistent_local_opt_gen_out]
+        gen_out = [tools.set_dtype_dimension(dtype, self.dimension) for dtype in persistent_local_opt_gen_out]
         user_keys = {'lb': self.lb,
                      'ub': self.ub,
                      'initial_sample_size': 1,
@@ -208,14 +209,3 @@ class libEnsembleOptimizer(Optimizer):
                 self.exit_criteria[key] = val
             else:
                 raise KeyError(f'{key} is not a valid exit criteria option for libEnsemble')
-
-
-def set_dtype_dimension(dtype, dimension):
-    if len(dtype) == 2:
-        return dtype
-    elif len(dtype) == 3:
-        new_dtype = dtype[0], dtype[1], (dimension,)
-        return new_dtype
-    else:
-        raise IndexError('size of dtype cannot be set')
-

--- a/rsopt/libe_tools/optimizer_aposmm.py
+++ b/rsopt/libe_tools/optimizer_aposmm.py
@@ -1,4 +1,5 @@
 import numpy as np
+from rsopt.libe_tools import tools
 from rsopt.libe_tools import optimizer
 from rsopt.libe_tools.interface import get_local_optimizer_method
 from libensemble.gen_funcs.persistent_aposmm import aposmm
@@ -44,7 +45,7 @@ class AposmmOptimizer(optimizer.libEnsembleOptimizer):
         # #   default left to APOSMM setting:
 
     def _configure_optimizer(self):
-        gen_out = [optimizer.set_dtype_dimension(dtype, self.dimension) for dtype in aposmm_gen_out]
+        gen_out = [tools.set_dtype_dimension(dtype, self.dimension) for dtype in aposmm_gen_out]
         if self._config.options.load_start_sample:
             self.H0 = process_start_sample(self._config.options.load_start_sample)
         software, method = split_method(self._config.method)

--- a/rsopt/libe_tools/optimizer_dlib.py
+++ b/rsopt/libe_tools/optimizer_dlib.py
@@ -1,4 +1,4 @@
-import numpy as np
+from rsopt.libe_tools import tools
 from rsopt.libe_tools import optimizer
 from rsopt.libe_tools.generator_functions.persistent_dlib import persistent_dlib
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens
@@ -13,7 +13,7 @@ class DlibOptimizer(optimizer.libEnsembleOptimizer):
         super().__init__()
 
     def _configure_optimizer(self):
-        gen_out = [optimizer.set_dtype_dimension(dtype, self.dimension) for dtype in pysot_gen_out]
+        gen_out = [tools.set_dtype_dimension(dtype, self.dimension) for dtype in pysot_gen_out]
         user_keys = {'lb': self.lb,
                      'ub': self.ub,
                      'dim': self._config.get_dimension(),

--- a/rsopt/libe_tools/optimizer_mobo.py
+++ b/rsopt/libe_tools/optimizer_mobo.py
@@ -1,3 +1,4 @@
+from rsopt.libe_tools import tools
 from rsopt.libe_tools import optimizer
 from rsopt.libe_tools.generator_functions.persistent_mobo import persistent_mobo
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens
@@ -11,7 +12,7 @@ class MoboOptimizer(optimizer.libEnsembleOptimizer):
         super().__init__()
 
     def _configure_optimizer(self):
-        gen_out = [optimizer.set_dtype_dimension(dtype, self.dimension) for dtype in mobo_gen_out]
+        gen_out = [tools.set_dtype_dimension(dtype, self.dimension) for dtype in mobo_gen_out]
         user_keys = {'lb': self.lb,
                      'ub': self.ub,
                      'dim': self._config.get_dimension(),

--- a/rsopt/libe_tools/optimizer_nsga2.py
+++ b/rsopt/libe_tools/optimizer_nsga2.py
@@ -1,3 +1,4 @@
+from rsopt.libe_tools import tools
 from rsopt.libe_tools import optimizer
 from libensemble.gen_funcs.persistent_deap_nsga2 import deap_nsga2
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens
@@ -15,7 +16,7 @@ class EvolutionaryOptimizer(optimizer.libEnsembleOptimizer):
 
     def _configure_optimizer(self):
 
-        gen_out = [optimizer.set_dtype_dimension(dtype, self.dimension) for dtype in nsga2_gen_out]
+        gen_out = [tools.set_dtype_dimension(dtype, self.dimension) for dtype in nsga2_gen_out]
 
         user_keys = {'lb': list(self.lb),  # DEAP requires lists
                      'ub': list(self.ub),

--- a/rsopt/libe_tools/optimizer_pysot.py
+++ b/rsopt/libe_tools/optimizer_pysot.py
@@ -1,4 +1,5 @@
 import numpy as np
+from rsopt.libe_tools import tools
 from rsopt.libe_tools import optimizer
 from rsopt.libe_tools.generator_functions.persistent_pysot import persistent_pysot
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens
@@ -13,7 +14,7 @@ class PysotOptimizer(optimizer.libEnsembleOptimizer):
         super().__init__()
 
     def _configure_optimizer(self):
-        gen_out = [optimizer.set_dtype_dimension(dtype, self.dimension) for dtype in pysot_gen_out]
+        gen_out = [tools.set_dtype_dimension(dtype, self.dimension) for dtype in pysot_gen_out]
         user_keys = {'lb': self.lb,
                      'ub': self.ub,
                      'dim': self._config.get_dimension(),

--- a/rsopt/libe_tools/tools.py
+++ b/rsopt/libe_tools/tools.py
@@ -48,3 +48,13 @@ def parse_stat_file(filename):
     df = pandas.DataFrame(parsed_lines, columns=DATAFRAME_COLUMNS)
 
     return df
+
+
+def set_dtype_dimension(dtype, dimension):
+    if len(dtype) == 2:
+        return dtype
+    elif len(dtype) == 3:
+        new_dtype = dtype[0], dtype[1], (dimension,)
+        return new_dtype
+    else:
+        raise IndexError('size of dtype cannot be set')

--- a/rsopt/libe_tools/tools.py
+++ b/rsopt/libe_tools/tools.py
@@ -1,4 +1,5 @@
 import re
+import numpy
 import pandas
 
 LIBE_STATS_FIELDS = ["Worker", ": sim_id", ": sim Time:", "Start:", "End:", "Status:", "\n"]
@@ -48,6 +49,14 @@ def parse_stat_file(filename):
     df = pandas.DataFrame(parsed_lines, columns=DATAFRAME_COLUMNS)
 
     return df
+
+
+def filter_completed_history(H: numpy.ndarray) -> numpy.ndarray:
+    completed = H['returned']
+    # If any points were given but not returned mark them not given
+    H['given'] = H['given'] * H['returned']
+
+    return H[~completed]
 
 
 def set_dtype_dimension(dtype, dimension):

--- a/rsopt/optimizer.py
+++ b/rsopt/optimizer.py
@@ -28,6 +28,7 @@ class Optimizer:
 
         self.working_directory = '.'
         self.clean_working_directory = False
+
     @property
     def lb(self):
         return self._config.get_parameters_list('get_lower_bound', formatter=np.array)
@@ -52,7 +53,7 @@ class Optimizer:
     def start(self, value=None):
         pass
 
-    def load_configuration(self, config):
+    def load_configuration(self, config: dict or PKDict or Configuration or str):
         """
         Load a configuration file to setup an optimization run.
         May be given as a dictionary or path to configuration stored in YAML format

--- a/rsopt/pkcli/sample.py
+++ b/rsopt/pkcli/sample.py
@@ -29,3 +29,18 @@ def start(config):
     H, persis_info, _ = runner.run()
     if _config.is_manager:
         util.save_final_history(config, _config, H, persis_info, nworkers, message='Ran start point')
+
+
+def restart(config, history, rerun_failed=''):
+    _config = run.startup_sequence(config)
+
+    try:
+        nworkers = _config.options.nworkers
+    except AttributeError:
+        # Sampler defaults to 1 worker if not set
+        nworkers = 1
+
+    runner = run.restart_sampler(_config, history)
+    H, persis_info, _ = runner.run()
+    if _config.is_manager:
+        util.save_final_history(config, _config, H, persis_info, nworkers, message='Finished rest of sampler')

--- a/rsopt/run.py
+++ b/rsopt/run.py
@@ -50,7 +50,14 @@ def single_sampler(config):
 
 
 def lh_sampler(config):
-    sample = LHSampler()
+    sample = sampler.LHSampler()
+    sample.load_configuration(config)
+
+    return sample
+
+
+def restart_sampler(config, history):
+    sample = sampler.RestartSampler(restart_from=history)
     sample.load_configuration(config)
 
     return sample

--- a/rsopt/run.py
+++ b/rsopt/run.py
@@ -1,9 +1,15 @@
-from rsopt.libe_tools.sampler import GridSampler, SingleSample, LHSampler
+from rsopt.libe_tools import sampler
 from rsopt import mpi
 from rsopt import parse
+from rsopt.configuration import Configuration
 
 
-def startup_sequence(config):
+def startup_sequence(config: str) -> Configuration:
+    """
+    Safely initialize rsopt accounting for the local MPI configuration (if any)
+    :param config: Path to configuration file that will be used
+    :return: (rsopt.configuration.configuration.Configuration) object
+    """
     config_yaml = parse.read_configuration_file(config)
     _config = parse.parse_yaml_configuration(config_yaml)
     mpi_environment = mpi.get_mpi_environment()
@@ -30,14 +36,14 @@ def local_optimizer(config):
 
 
 def grid_sampler(config):
-    sample = GridSampler()
+    sample = sampler.GridSampler()
     sample.load_configuration(config)
 
     return sample
 
 
 def single_sampler(config):
-    sample = SingleSample()
+    sample = sampler.SingleSample()
     sample.load_configuration(config)
 
     return sample


### PR DESCRIPTION
Main feature is enabling restart of mesh_scan parameter scan's automatically by providing the history file to restart from.
Example of the feature is included.

There is a considerable amount of extra work included on this branch. Most of it is non-functional changes such as documentation and typing hints.