### PR TITLE
Removing MPI initialization from module testing

### DIFF
--- a/rsopt/mpi.py
+++ b/rsopt/mpi.py
@@ -1,7 +1,8 @@
 
 def get_mpi_environment():
     try:
-        from mpi4py import MPI
+        import mpi4py
+        mpi4py.rc.initialize = False
     except ModuleNotFoundError:
         # mpi4py not installed so it can't be used
         return
@@ -11,6 +12,8 @@ def get_mpi_environment():
         # (if user did start MPI with size 1 this would be an illegal configuration since: main + 1 worker = 2 ranks)
         return
 
+    from mpi4py import MPI
+    MPI.Init()
     nworkers = MPI.COMM_WORLD.Get_size() - 1
     is_manager = MPI.COMM_WORLD.Get_rank() == 0
     mpi_environment = {'mpi_comm': MPI.COMM_WORLD, 'comms': 'mpi', 'nworkers': nworkers, 'is_manager': is_manager}

--- a/rsopt/util.py
+++ b/rsopt/util.py
@@ -55,11 +55,14 @@ def return_nodelist(nodelist_string):
 def return_used_nodes():
     """Returns all used processor names to rank 0 or an empty list if MPI not used. For ranks != 0  returns None."""
     try:
-        from mpi4py import MPI
+        import mpi4py
+        mpi4py.rc.initialize = False
     except ModuleNotFoundError:
         # If MPI not being used to start rsopt then no nodes will have srun executed yet
         return []
 
+    from mpi4py import MPI
+    MPI.Init()
     rank = MPI.COMM_WORLD.Get_rank()
     name = MPI.Get_processor_name()
     all_names = MPI.COMM_WORLD.gather(name, root=0)
@@ -93,11 +96,14 @@ def return_unused_node():
 def broadcast(data, root_rank=0):
     """broadcast, or don't bother"""
     try:
-        from mpi4py import MPI
+        import mpi4py
+        mpi4py.rc.initialize = False
     except ModuleNotFoundError:
         # If MPI not available for import then assume it isn't needed
         return data
 
+    from mpi4py import MPI
+    MPI.Init()
     if MPI.COMM_WORLD.Get_size() == 1:
         return data
 


### PR DESCRIPTION
Removes MPI intiialization routine from mpi4py module loading and checking. Allows for significantly more flexibility.

This will likely fail if the module is installed, but won't work even though it imports correctly. Allows for runs within an `salloc` environment on cori and on nersc login nodes