### PR TITLE
148 run python simulations in subprocess

### DIFF
--- a/docs/codes/python.rst
+++ b/docs/codes/python.rst
@@ -21,6 +21,19 @@ Required ``setup`` fields for ``python`` are:
 * ``function``: Name of a function in `input_file` to be executed
 * ``execution_type``: Method to use when executing the Python code. See :ref:`Execution Methods<exec_methods>` for accepted types.
 
+Optional fields:
+
+* ``serial_mode``: By default Python functions will be executed directly by the assigned Worker process. This is convenient
+from a speed-of-execution perspective but can cause problems in some cases. For example if the code being executed by the Job
+requires special cleanup between executions; or if you expect some Jobs to fail, this will result in rsopt exiting
+prematurely since the error will occur directly on the process. In these cases it can be useful to select an alternate mode.
+    - `worker`: The default option. Python functions are executed directly by the worker process.
+    - `process`: The worker will initiate a subprocess to run the function. Return values of the function will be automatically
+                 passed back to rsopt. This option should be selected if it is required that each simulation be initiated
+                 in a clean memory space. This option does carry the highest overhead.
+    - `thread`: Run the function in a thread. Memory is still shared, but errors produced by the simulation function
+                will normally not be fatal for the rsopt process. Overhead cost should normally be on par with `worker`.
+
 ``function`` Specification
 --------------------------
 

--- a/docs/codes/python.rst
+++ b/docs/codes/python.rst
@@ -23,7 +23,7 @@ Required ``setup`` fields for ``python`` are:
 
 Optional fields:
 
-* ``serial_mode``: By default Python functions will be executed directly by the assigned Worker process. This is convenient from a speed-of-execution perspective but can cause problems in some cases. For example if the code being executed by the Job requires special cleanup between executions; or if you expect some Jobs to fail, this will result in rsopt exiting prematurely since the error will occur directly on the process. In these cases it can be useful to select an alternate mode.
+* ``serial_python_mode``: By default Python functions will be executed directly by the assigned Worker process. This is convenient from a speed-of-execution perspective but can cause problems in some cases. For example if the code being executed by the Job requires special cleanup between executions; or if you expect some Jobs to fail, this will result in rsopt exiting prematurely since the error will occur directly on the process. In these cases it can be useful to select an alternate mode.
 
     - `worker`: The default option. Python functions are executed directly by the worker process.
     - `process`: The worker will initiate a subprocess to run the function. Return values of the function will be automatically passed back to rsopt. This option should be selected if it is required that each simulation be initiated in a clean memory space. This option does carry the highest overhead.

--- a/docs/codes/python.rst
+++ b/docs/codes/python.rst
@@ -23,16 +23,11 @@ Required ``setup`` fields for ``python`` are:
 
 Optional fields:
 
-* ``serial_mode``: By default Python functions will be executed directly by the assigned Worker process. This is convenient
-from a speed-of-execution perspective but can cause problems in some cases. For example if the code being executed by the Job
-requires special cleanup between executions; or if you expect some Jobs to fail, this will result in rsopt exiting
-prematurely since the error will occur directly on the process. In these cases it can be useful to select an alternate mode.
+* ``serial_mode``: By default Python functions will be executed directly by the assigned Worker process. This is convenient from a speed-of-execution perspective but can cause problems in some cases. For example if the code being executed by the Job requires special cleanup between executions; or if you expect some Jobs to fail, this will result in rsopt exiting prematurely since the error will occur directly on the process. In these cases it can be useful to select an alternate mode.
+
     - `worker`: The default option. Python functions are executed directly by the worker process.
-    - `process`: The worker will initiate a subprocess to run the function. Return values of the function will be automatically
-                 passed back to rsopt. This option should be selected if it is required that each simulation be initiated
-                 in a clean memory space. This option does carry the highest overhead.
-    - `thread`: Run the function in a thread. Memory is still shared, but errors produced by the simulation function
-                will normally not be fatal for the rsopt process. Overhead cost should normally be on par with `worker`.
+    - `process`: The worker will initiate a subprocess to run the function. Return values of the function will be automatically passed back to rsopt. This option should be selected if it is required that each simulation be initiated in a clean memory space. This option does carry the highest overhead.
+    - `thread`: Run the function in a thread. Memory is still shared, but errors produced by the simulation function will normally not be fatal for the rsopt process. Overhead cost should normally be on par with `worker`.
 
 ``function`` Specification
 --------------------------

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -95,7 +95,7 @@ Serial Python Fields
 --------------------
 For serial Python an additional field can be given to specify how the Python function should be executed by the worker.
 
-- `serial_mode` [str]
+- `serial_python_mode` [str]
     Can be ``thread``, ``process``, or ``worker``. Default is ``worker``. See :ref:`Python<codes/python>` for a
     description of the options.
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,0 +1,100 @@
+.. _options_ref:
+
+Setup
+=====
+The `setup` block is required to be defined for each code in the `codes` list (see :doc:`Configuration<configuration>`).
+The `setup` block handles specification of input files, execution method, and any pre/post processing functions which
+will be run for the code. General options that can be used for setup of any code are described below. Special
+consideration should be given when configuring :ref:`Python<codes/python>` jobs. Since rsopt is a Python program there are additional options
+for how Python jobs should be executed. See :ref:`Python<codes/python>` for information.
+
+
+General Setup Fields
+--------------------
+
+- `input_file` [str]:
+    Path to the location of the input file for this code instance.
+- `execution_type` [str]:
+    Specify the method used to run the code. Availability may vary depending on resources being used. Available options
+    are. Nested entries are additional fields that may be specified for the given mode.:
+        * ``serial``: Serial execution of the code. If ``serial`` mode is used the simulation will always be executed on
+                        the same resources as the worker assigned the job. This can be a consideration if many workers
+                        will be running computationally intensive work.
+        * ``parallel``: Parallel execution of the code with MPI. libEnsemble automatically detects MPI implementation and will automatically format input commands
+        * ``shifter``: For use on NERSC. Runs inside of a Shifter container from the radiasoft/sirepo:prod image.
+            - ``shifter_image`` can also be provided in Setup to request a particular image. The default is `radiasoft/sirepo:prod`.
+        * ``rsmpi``: Special command for users who have servers registered to them on jupyter.radiasoft.org_. If rsmpi is being used for any code it must be used for all. The number of cores requested may vary from code to code though.
+- `cores` [int]:
+    Number of cores to use for parallel run modes (``parallel``, ``shifter``, ``rsmpi``). This is ignored for ``serial``.
+    By default if `cores: 1` is given then rsopt will use ``serial`` execution, if available. This behavior can be
+    overridden by specifying ``force_executor: True``
+- `force_executor` [bool]:
+    If True then ``parallel`` execution will be used if available even if only 1 core has been requested. Can be useful
+    to ensure that non-worker nodes (when available) are used for computationally-intensive, single-core simulations;
+    as the libEnsemble Executor will then handle distribution of the simulations to open resources.
+- `timeout` [float]:
+    If a simulation does not complete in `timeout` seconds the simulation will be ended and marked failed. Not currently
+    an option for ``serial`` Python simulations.
+- `preprocess` [list(str, str)]
+    Can be used to provide a Python function that will be run prior to the simulation starting. Given as a list with
+    list(python_file_name, function_name_in_python_file) For instance:
+
+    .. code-block:: yaml
+
+      - opal:
+          settings:
+          parameters:
+          setup:
+            preprocess: [processes.py, my_preprocess]
+
+    Where `my_preprocess` is a function defined in the file `processes.py`. For a full description of how to use
+    pre and post processes see the :doc:`Job Dictionary<job_dictionary>` page.
+- `postprocess` [list(str,str)]
+    This is identical to `preprocess` except the `postprocess` will be run after the simulation ends.
+    See the :doc:`Job Dictionary<job_dictionary>` page for details on writing postprocess functions.
+- `code_arguments`:
+    Can be used to provide arguments that will be given to the code execution
+    in the Setup block at run time. For example:
+
+    .. code-block:: yaml
+
+      - opal:
+          settings:
+          parameters:
+          setup:
+            input_file: opal.in
+            execution_type: serial
+            code_arguments:
+              "--info": 4
+              "--help-command": Monitor
+              "--git-revision":
+
+    Would execute OPAL with `opal --info 4 --help-command Monitor --git-revision  opal.in`.
+
+Templated Code Fields
+---------------------
+Additional specifications that can be given under `setup` for templated codes only, that is: elegant, MAD-X, OPAL, and
+Genesis. In particular there is special handling in rsopt for converting particle phase space distribution files between these four codes.
+- `input_distribution` [str]
+    Name of the initial distribution file that the simulation expects to read in. If this simulation is not the first
+    in the list of `codes` in the configuration file then the preceding code's `output_distribution` will be used to
+    create the `input_distribution`.
+- `output_distribution` [str]
+    The name of the distribution file that simulation will produce at its completion. If the next `code` in the list
+    has `input_distribution` specified the `input_distribution` will be created from this `output_distribution`.
+- `ignored_files` [list(str)]
+    This is a list of files that will be ignored when the input files for the simulation are parsed. Normally,
+    rsopt verifies that all external resource files needed to run the simulation already exist
+    (e.g. particle distributions, wakefields, field maps). Sometimes these files might be created by a preceding
+    step in the rsopt run. In this case the file names can be added to this list and their existence will not be checked
+    until the simulation starts. Files given under the `input_distribution` are automatically added to this list since
+    rsopt will create them.
+
+Serial Python Fields
+--------------------
+For serial Python an additional field can be given to specify how the Python function should be executed by the worker.
+- `serial_mode` [str]
+    Can be ``thread``, ``process``, or ``worker``. Default is ``worker``. See :ref:`Python<codes/python>` for a
+    description of the options.
+
+

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -17,13 +17,13 @@ General Setup Fields
 - `execution_type` [str]:
     Specify the method used to run the code. Availability may vary depending on resources being used. Available options
     are. Nested entries are additional fields that may be specified for the given mode.:
-        * ``serial``: Serial execution of the code. If ``serial`` mode is used the simulation will always be executed on
-                        the same resources as the worker assigned the job. This can be a consideration if many workers
-                        will be running computationally intensive work.
+
+        * ``serial``: Serial execution of the code. If ``serial`` mode is used the simulation will always be executed on the same resources as the worker assigned the job. This can be a consideration if many workers will be running computationally intensive work.
         * ``parallel``: Parallel execution of the code with MPI. libEnsemble automatically detects MPI implementation and will automatically format input commands
         * ``shifter``: For use on NERSC. Runs inside of a Shifter container from the radiasoft/sirepo:prod image.
             - ``shifter_image`` can also be provided in Setup to request a particular image. The default is `radiasoft/sirepo:prod`.
         * ``rsmpi``: Special command for users who have servers registered to them on jupyter.radiasoft.org_. If rsmpi is being used for any code it must be used for all. The number of cores requested may vary from code to code though.
+
 - `cores` [int]:
     Number of cores to use for parallel run modes (``parallel``, ``shifter``, ``rsmpi``). This is ignored for ``serial``.
     By default if `cores: 1` is given then rsopt will use ``serial`` execution, if available. This behavior can be
@@ -75,6 +75,7 @@ Templated Code Fields
 ---------------------
 Additional specifications that can be given under `setup` for templated codes only, that is: elegant, MAD-X, OPAL, and
 Genesis. In particular there is special handling in rsopt for converting particle phase space distribution files between these four codes.
+
 - `input_distribution` [str]
     Name of the initial distribution file that the simulation expects to read in. If this simulation is not the first
     in the list of `codes` in the configuration file then the preceding code's `output_distribution` will be used to
@@ -93,6 +94,7 @@ Genesis. In particular there is special handling in rsopt for converting particl
 Serial Python Fields
 --------------------
 For serial Python an additional field can be given to specify how the Python function should be executed by the worker.
+
 - `serial_mode` [str]
     Can be ``thread``, ``process``, or ``worker``. Default is ``worker``. See :ref:`Python<codes/python>` for a
     description of the options.

--- a/rsopt/codes/serial_python.py
+++ b/rsopt/codes/serial_python.py
@@ -1,0 +1,50 @@
+import threading
+import multiprocessing
+from libensemble import message_numbers
+
+SERIAL_MODE_DEFAULT = 'worker'
+RESULT = 'result'
+CODE = 'return_code'
+_NULL_RESULT = 'xo9cHSVI35KmWc1V'
+
+
+def run_process(function, *args, **kwargs):
+    p = multiprocessing.Process(target=function, args=args, kwargs=kwargs)
+    p.start()
+    p.join()
+
+
+def _thread_wrapper(function, container, *args, **kwargs):
+    result = function(*args, **kwargs)
+    container[0] = result
+
+
+def run_thread(function, *args, **kwargs):
+    container = [_NULL_RESULT]
+    p = threading.Thread(target=_thread_wrapper,
+                         args=(function, container, *args), kwargs=kwargs)
+    p.start()
+    p.join()
+
+    if container[0] == _NULL_RESULT:
+        return_code = message_numbers.TASK_FAILED
+    else:
+        return_code = message_numbers.WORKER_DONE
+
+    return {RESULT: container[0], CODE: return_code}
+
+
+def run_worker(function, *args, **kwargs):
+    result = function(*args, **kwargs)
+
+    # If function fails this return will not be reached so return_code is always success
+    return {RESULT: result, CODE: message_numbers.WORKER_DONE}
+
+
+def serial_runner(serial_mode, function, *args, **kwargs) -> dict:
+    return SERIAL_MODES[serial_mode](function, *args, **kwargs)
+
+
+SERIAL_MODES = {'process': run_process,
+                'thread': run_thread,
+                'worker': run_worker}

--- a/rsopt/codes/serial_python.py
+++ b/rsopt/codes/serial_python.py
@@ -1,6 +1,7 @@
 import threading
 import multiprocessing
 from libensemble import message_numbers
+from typing import Callable
 
 SERIAL_MODE_DEFAULT = 'worker'
 RESULT = 'result'
@@ -13,7 +14,19 @@ def _process_wrapper(function, queue, *args, **kwargs):
     queue.put(result)
 
 
-def run_process(function, *args, **kwargs):
+def run_process(function: Callable, *args, **kwargs) -> dict:
+    """ Run function in a subprocess.
+
+    If the function fails the result in the returned dictionary will be None.
+
+    Args:
+        function: (Callable) Function to be executed
+        *args: (list) Arguments passed to the Python simulation function.
+        **kwargs: (dict) Key word arguments passed to the Python simulation function.
+
+    Returns:
+        (dict) Dictionary with result of simulation (if any) and return code.
+    """
     result_queue = multiprocessing.Queue()
     p = multiprocessing.Process(target=_process_wrapper,
                                 args=(function, result_queue, *args), kwargs=kwargs)
@@ -35,7 +48,19 @@ def _thread_wrapper(function, container, *args, **kwargs):
     container[0] = result
 
 
-def run_thread(function, *args, **kwargs):
+def run_thread(function: Callable, *args, **kwargs) -> dict:
+    """ Run function in a thread.
+
+    If the function fails the result in the returned dictionary will be None.
+
+    Args:
+        function: (Callable) Function to be executed
+        *args: (list) Arguments passed to the Python simulation function.
+        **kwargs: (dict) Key word arguments passed to the Python simulation function.
+
+    Returns:
+        (dict) Dictionary with result of simulation (if any) and return code.
+    """
     container = [_NULL_RESULT]
     p = threading.Thread(target=_thread_wrapper,
                          args=(function, container, *args), kwargs=kwargs)
@@ -52,15 +77,23 @@ def run_thread(function, *args, **kwargs):
     return {RESULT: result, CODE: return_code}
 
 
-def run_worker(function, *args, **kwargs):
+def run_worker(function: Callable, *args, **kwargs) -> dict:
+    """ Run function in a subprocess.
+
+    If the function has an error then rsopt with crash, and you don't need to about worry what is in the result.
+
+    Args:
+        function: (Callable) Function to be executed
+        *args: (list) Arguments passed to the Python simulation function.
+        **kwargs: (dict) Key word arguments passed to the Python simulation function.
+
+    Returns:
+        (dict) Dictionary with result of simulation (if any) and return code.
+    """
     result = function(*args, **kwargs)
 
     # If function fails this return will not be reached so return_code is always success
     return {RESULT: result, CODE: message_numbers.WORKER_DONE}
-
-
-def serial_runner(serial_mode, function, *args, **kwargs) -> dict:
-    return SERIAL_MODES[serial_mode](function, *args, **kwargs)
 
 
 SERIAL_MODES = {'process': run_process,

--- a/rsopt/codes/serial_python.py
+++ b/rsopt/codes/serial_python.py
@@ -19,13 +19,14 @@ def run_process(function, *args, **kwargs):
                                 args=(function, result_queue, *args), kwargs=kwargs)
     p.start()
     p.join()
-    result = result_queue.get()
-
+    
     if p.exitcode != 0:
         return_code = message_numbers.TASK_FAILED
+        result = None
     else:
         return_code = message_numbers.WORKER_DONE
-
+        result = result_queue.get()
+    
     return {RESULT: result, CODE: return_code}
 
 

--- a/rsopt/codes/serial_python.py
+++ b/rsopt/codes/serial_python.py
@@ -44,10 +44,12 @@ def run_thread(function, *args, **kwargs):
 
     if container[0] == _NULL_RESULT:
         return_code = message_numbers.TASK_FAILED
+        result = None
     else:
         return_code = message_numbers.WORKER_DONE
+        result = container[0]
 
-    return {RESULT: container[0], CODE: return_code}
+    return {RESULT: result, CODE: return_code}
 
 
 def run_worker(function, *args, **kwargs):

--- a/rsopt/configuration/jobs.py
+++ b/rsopt/configuration/jobs.py
@@ -82,7 +82,16 @@ class Job:
         else:
             return None
 
-    def execute(self, *args, **kwargs):
+    def execute(self, *args, **kwargs) -> dict:
+        """ Execute a Python simulation.
+
+        Args:
+            *args: (list) Arguments passed to the Python simulation function.
+            **kwargs: (dict) Key word arguments passed to the Python simulation function.
+
+        Returns:
+            (dict) Dictionary with result of simulation (if any) and return code.
+        """
         executor = serial_python.SERIAL_MODES[self.setup.get('serial_mode', serial_python.SERIAL_MODE_DEFAULT)]
         return executor(self._setup.function, *args, **kwargs)
 

--- a/rsopt/configuration/jobs.py
+++ b/rsopt/configuration/jobs.py
@@ -92,7 +92,7 @@ class Job:
         Returns:
             (dict) Dictionary with result of simulation (if any) and return code.
         """
-        executor = serial_python.SERIAL_MODES[self.setup.get('serial_mode', serial_python.SERIAL_MODE_DEFAULT)]
+        executor = serial_python.SERIAL_MODES[self.setup.get('serial_python_mode', serial_python.SERIAL_MODE_DEFAULT)]
         return executor(self._setup.function, *args, **kwargs)
 
     @property

--- a/rsopt/configuration/jobs.py
+++ b/rsopt/configuration/jobs.py
@@ -3,6 +3,7 @@ from rsopt.configuration.settings import SETTING_READERS, Settings
 from rsopt.configuration.setup import SETUP_READERS
 from rsopt.configuration.setup.python import _PARALLEL_PYTHON_RUN_FILE
 from rsopt.configuration.setup.setup import Setup
+from rsopt.codes import serial_python
 import typing
 
 _USE_SIM_DIRS_DEFAULT = ['elegant', 'opal', 'genesis']
@@ -81,9 +82,9 @@ class Job:
         else:
             return None
 
-    @property
-    def execute(self):
-        return self._setup.function
+    def execute(self, *args, **kwargs):
+        executor = serial_python.SERIAL_MODES[self.setup.get('serial_mode', serial_python.SERIAL_MODE_DEFAULT)]
+        return executor(self._setup.function, *args, **kwargs)
 
     @property
     def is_parallel(self) -> bool:

--- a/rsopt/configuration/setup/python.py
+++ b/rsopt/configuration/setup/python.py
@@ -15,6 +15,7 @@ _TEMPLATE_PATH = pkio.py_path(pkresource.filename(''))
 @Setup.register_setup()
 class Python(Setup):
     __REQUIRED_KEYS = ('function',)
+    _OPTIONAL_KEYS = ('serial_python_mode',)
     SERIAL_RUN_COMMAND = None  # serial not executed by subprocess so no run command is needed
     PARALLEL_RUN_COMMAND = 'python'
     NAME = 'python'
@@ -47,7 +48,7 @@ class Python(Setup):
         # Validate for all keys (field in config file) are known to setup
         for key in setup.keys():
             # Can be made private if non-required code-specific fields are ever added
-            if key not in (cls._KNOWN_KEYS + cls.__REQUIRED_KEYS):
+            if key not in (cls._known_keys() + cls.__REQUIRED_KEYS):
                 raise KeyError(f'{key} in setup block for code-type {code} is not recognized.')
         Setup.check_setup(setup)
 

--- a/rsopt/configuration/setup/python.py
+++ b/rsopt/configuration/setup/python.py
@@ -11,6 +11,7 @@ _PARALLEL_PYTHON_TEMPLATE = 'run_parallel_python.py.jinja'
 _PARALLEL_PYTHON_RUN_FILE = 'run_parallel_python.py'
 _TEMPLATE_PATH = pkio.py_path(pkresource.filename(''))
 
+
 @Setup.register_setup()
 class Python(Setup):
     __REQUIRED_KEYS = ('function',)
@@ -19,7 +20,7 @@ class Python(Setup):
     NAME = 'python'
 
     @property
-    def function(self):
+    def function(self) -> typing.Callable:
         if self.setup.get('input_file'):
             # libEnsemble workers change active directory - sys.path will not record locally available modules
             sys.path.append('.')

--- a/rsopt/configuration/setup/setup.py
+++ b/rsopt/configuration/setup/setup.py
@@ -59,7 +59,7 @@ class Setup(abc.ABC):
     _REQUIRED_KEYS = ('execution_type',)  # code specific keys that are required
     _OPTIONAL_KEYS = ()  # code specific keys that are not required
     # keys that can be used by any code
-    _KNOWN_KEYS = tuple(pkyaml.load_file(SETUP_SCHEMA)) + _REQUIRED_KEYS + _OPTIONAL_KEYS
+    _KNOWN_KEYS = tuple(pkyaml.load_file(SETUP_SCHEMA)) #+ _REQUIRED_KEYS + _OPTIONAL_KEYS
     SERIAL_RUN_COMMAND = None
     PARALLEL_RUN_COMMAND = None
     NAME = None
@@ -75,6 +75,10 @@ class Setup(abc.ABC):
                          'postprocess': self._handle_postprocess}
         self.preprocess = []
         self.postprocess = []
+
+    @classmethod
+    def _known_keys(cls) -> tuple:
+        return cls._KNOWN_KEYS + cls._REQUIRED_KEYS + cls._OPTIONAL_KEYS
 
     @classmethod
     def register_setup(cls):

--- a/rsopt/package_data/setup_schema.yml
+++ b/rsopt/package_data/setup_schema.yml
@@ -12,3 +12,4 @@
 - ignored_files
 - shifter_image
 - code_arguments
+- serial_mode

--- a/rsopt/package_data/setup_schema.yml
+++ b/rsopt/package_data/setup_schema.yml
@@ -12,4 +12,3 @@
 - ignored_files
 - shifter_image
 - code_arguments
-- serial_mode

--- a/rsopt/simulation.py
+++ b/rsopt/simulation.py
@@ -7,7 +7,7 @@ import rsopt.util
 from libensemble import message_numbers
 from libensemble.executors.executor import Executor
 from collections.abc import Iterable
-
+from rsopt.codes.serial_python import RESULT, CODE
 # TODO: This should probably be in libe_tools right?
 
 _POLL_TIME = 1  # seconds
@@ -148,8 +148,9 @@ class SimulationFunction:
                         break
             else:
                 # Serial Python Job
-                f = job.execute(**kwargs)
-                self.J['sim_status'] = message_numbers.WORKER_DONE
+                result_dict = job.execute(**kwargs)
+                f = result_dict[RESULT]
+                self.J['sim_status'] = result_dict[CODE]
                 # NOTE: Right now f is not passed to the objective function. Would need to go inside J. Or pass J into
                 #       function job.execute(**kwargs)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -36,7 +36,7 @@ class TestSetupFeatures(unittest.TestCase):
 
         frame = tools.parse_stat_file('libE_stats.txt')
         frame.to_csv('resr.csv')
-        for row in frame.status[:2]:
+        for row in frame.status[1:3]:
             self.assertEqual(row, TIMEOUT_STATUS_MESSAGE)
 
     def test_executor_complete_with_timeout(self):
@@ -50,7 +50,7 @@ class TestSetupFeatures(unittest.TestCase):
         H, persis_info, _ = runner.run()
 
         frame = tools.parse_stat_file('libE_stats.txt')
-        for row in frame.status[:2]:
+        for row in frame.status[1:3]:
             self.assertEqual(row, COMPLETED_STATUS_MESSAGE)
 
     def test_force_executor(self):


### PR DESCRIPTION
TODO:

- [x] Handle no result explicitly in threaded 
- [x] Timing comparison
- [x] New documentation section on Setup block and execution options
- [x] docstrings and type annotations
- [x] Run tests in beamsim